### PR TITLE
Fix the playback speed issue

### DIFF
--- a/WaveEditor_Group1/Source/AudioProcessingComponent.cpp
+++ b/WaveEditor_Group1/Source/AudioProcessingComponent.cpp
@@ -198,16 +198,24 @@ void AudioProcessingComponent::setState (TransportState newState)
 //-------------------------------POSITION HANDLING-------------------------------------
 void AudioProcessingComponent::setPositionInS(AudioProcessingComponent::PositionType positionType, double newPosition)
 {
+    int position = static_cast<int>(newPosition * sampleRate);
+
+    // make sure the position is in the range
+    if (position < 0)
+        position = 0;
+    else if (position >= getNumSamples())
+        position = getNumSamples() - 1;
+
     switch (positionType)
     {
         case Cursor:
-            currentPos = static_cast<int>(newPosition * sampleRate);
+            currentPos = position;
             break;
         case MarkerStart:
-            markerStartPos = static_cast<int>(newPosition * sampleRate);
+            markerStartPos = position;
             break;
         case MarkerEnd:
-            markerEndPos = static_cast<int>(newPosition * sampleRate);
+            markerEndPos = position;
             break;
     }
 }

--- a/WaveEditor_Group1/Source/AudioProcessingComponent.cpp
+++ b/WaveEditor_Group1/Source/AudioProcessingComponent.cpp
@@ -67,9 +67,8 @@ void AudioProcessingComponent::getNextAudioBlock (const AudioSourceChannelInfo& 
         while (outputSamplesRemaining > 0)
         {
             auto bufferSamplesRemaining = markerEndPos - currentPos;
-            auto outputSamplesThisTime = jmin (outputSamplesRemaining,
-                                               static_cast<int>(bufferSamplesRemaining*sampleRateRatio));
-            auto inputSamplesThisTime = static_cast<int>(outputSamplesThisTime / sampleRateRatio);
+            auto inputSamplesThisTime = jmin(bufferSamplesRemaining, static_cast<int>(outputSamplesRemaining/sampleRateRatio));
+            auto outputSamplesThisTime = static_cast<int>(round(inputSamplesThisTime * sampleRateRatio));
 
             for (auto channel = 0; channel < numOutputChannels; channel++)
             {

--- a/WaveEditor_Group1/Source/AudioProcessingComponent.cpp
+++ b/WaveEditor_Group1/Source/AudioProcessingComponent.cpp
@@ -239,6 +239,17 @@ void AudioProcessingComponent::loadFile(File file)
     auto* reader = formatManager.createReaderFor (file);
     if (reader != nullptr)
     {
+        // if there's a file has been loaded, clean the interpolators
+        if (fileLoaded)
+        {
+            for (int channel=0; channel<getNumChannels(); channel++)
+            {
+                delete interpolators[channel];
+            }
+            delete[] interpolators;
+            interpolators = nullptr;
+        }
+
         // read the entire audio into audioBuffer
         auto numSamples = reader->lengthInSamples;
         auto numChannels = reader->numChannels;
@@ -251,15 +262,7 @@ void AudioProcessingComponent::loadFile(File file)
         // set sample rate
         sampleRate = reader->sampleRate;
 
-        if (fileLoaded) // if there's a file has been loaded, clean the interpolators
-        {
-            for (int channel=0; channel<numChannels; channel++)
-            {
-                delete interpolators[channel];
-            }
-            delete[] interpolators;
-            interpolators = nullptr;
-        }
+        // create interpolators
         interpolators = new CatmullRomInterpolator*[numChannels];
         for (int channel=0; channel<numChannels; channel++)
             interpolators[channel] = new CatmullRomInterpolator();

--- a/WaveEditor_Group1/Source/AudioProcessingComponent.h
+++ b/WaveEditor_Group1/Source/AudioProcessingComponent.h
@@ -102,6 +102,10 @@ public:
     */
     int getNumChannels();
 
+    /*! Returns the number of samples of audio data
+    */
+    int getNumSamples();
+
     /*! Returns the current sample rate
     */
     double getSampleRate();
@@ -130,33 +134,23 @@ public:
     ChangeBroadcaster blockReady;               //!< public broadcaster for the transport state
 
 private:
-    
-
-    /*! Fill the audioSampleBuffer with new coming data.
-        @param channelData one channel of data.
-        @param numChannel the number of channel that will be filled.
-    */
-    void fillAudioBlockBuffer(const float* channelData, int numChannel);
 
     /*! Internal function to change the transport state
     */
     void setState(TransportState state);
 
     AudioFormatManager formatManager;
-
-    TransportState state;       //!< enum
-
+    TransportState state;
     bool fileLoaded;  // indicates if a file is loaded
+    CatmullRomInterpolator** interpolators;
 
     //// AudioBuffer
     // buffer definitions
     AudioBuffer<float> audioBlockBuffer;
     AudioBuffer<float> audioBuffer;
     // meta info
-    unsigned int numChannels;
-    int numBlockSamples;
     double sampleRate;
-    juce::int64 numAudioSamples;
+    double deviceSampleRate;
     // position info (the unit is always in sample)
     int currentPos;
     int markerStartPos;


### PR DESCRIPTION
Fixes #9. Interpolators are used in `getNextAudioBlock`.

https://docs.juce.com/master/classCatmullRomInterpolator.html